### PR TITLE
change travis file to sudo: false to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: r
 warnings_are_errors: true
 cache: packages
-sudo: required
+sudo: false
 r: 
   - release
   - devel


### PR DESCRIPTION
hey @seaaan   - going through all ropensci repos trying to speed up Travis builds by using container based builds whenever possible 

the build https://travis-ci.org/ropenscilabs/plater/builds/209085211 isn't faster than the others on the first run, but should be faster the next time since deps are cached